### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Meilisearch MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@devlimelabs/meilisearch-ts-mcp)](https://smithery.ai/server/@devlimelabs/meilisearch-ts-mcp)
+
 A Model Context Protocol (MCP) server implementation for Meilisearch, enabling AI assistants to interact with Meilisearch through a standardized interface.
 
 ## Features
@@ -14,6 +16,15 @@ A Model Context Protocol (MCP) server implementation for Meilisearch, enabling A
 
 ## Installation
 
+### Installing via Smithery
+
+To install Meilisearch MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@devlimelabs/meilisearch-ts-mcp):
+
+```bash
+npx -y @smithery/cli install @devlimelabs/meilisearch-ts-mcp --client claude
+```
+
+### Manual Installation
 1. Clone the repository:
    ```bash
    git clone https://github.com/devlimelabs/meilisearch-ts-mcp.git

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,31 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    properties:
+      MEILISEARCH_HOST:
+        type: string
+        default: http://localhost:7700
+        description: URL for the Meilisearch instance
+      MEILISEARCH_API_KEY:
+        type: string
+        default: ""
+        description: API key for Meilisearch, if required
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({
+      command: 'node',
+      args: ['dist/index.js'],
+      env: {
+        NODE_ENV: 'production',
+        MEILISEARCH_HOST: config.MEILISEARCH_HOST,
+        MEILISEARCH_API_KEY: config.MEILISEARCH_API_KEY
+      }
+    })
+  exampleConfig:
+    MEILISEARCH_HOST: http://localhost:7700
+    MEILISEARCH_API_KEY: your-api-key


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@devlimelabs/meilisearch-ts-mcp?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂